### PR TITLE
Fix building on Mac OS X/macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,8 @@ set(META_VERSION_MINOR 0)
 set(META_VERSION_PATCH 0)
 set(META_APP_VERSION ${META_VERSION_MAJOR}.${META_VERSION_MINOR}.${META_VERSION_PATCH})
 
+project(${META_PROJECT_NAME})
+
 # add project files
 set(HEADER_FILES
     misc/xmlparsermacros.h


### PR DESCRIPTION
Without project(), compiler flags like -std=gnu++17 are not applied
for non-Apple clang on Mac OS X/macOS.

Similar to https://github.com/Martchus/cpp-utilities/pull/15.